### PR TITLE
Use /usr/bin/env

### DIFF
--- a/src/cfg_generator.py
+++ b/src/cfg_generator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 import random
 
 class Grammar:

--- a/src/generate_flavours.py
+++ b/src/generate_flavours.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import cfg_generator
 import logging


### PR DESCRIPTION
Make the usagege of python3 more explicit. There are still systems were
/usr/bin/python defaults to python2(.7).