### PR TITLE
Do (almost) everything with the grammar only.

### DIFF
--- a/src/generate_flavours.py
+++ b/src/generate_flavours.py
@@ -6,25 +6,10 @@ from tony_cfg import tony_en as cfg
 
 def format_output(generatedoutput):
     ingredients = list(cfg_generator.flatten(generatedoutput))
-    logging.info("fixing percentage...")
-    for index,ingredient in enumerate(ingredients):
-        if "%" in ingredient: # vieze fix percentage
-            puur_index = index-1
-            ingredients[index]= ingredients[puur_index] + " " + ingredients[index]
-            ingredients.pop(puur_index)
-    logging.info("fixing crumble...")
-    for index,ingredient in enumerate(ingredients):
-        if ingredient == "crumble": # crumble can never be the first item
-            fruit_index = index-1
-            ingredients[index]= ingredients[fruit_index] + " " + "crumble"
-            ingredients.pop(fruit_index)
-    logging.info("Fixing duplicates...")
-    ingredients = list(dict.fromkeys(ingredients))
-    if len(ingredients) > 2:
-        smaak = '{} with {} and {}'.format(ingredients[0], ', '.join(ingredients[1:-1]), ingredients[-1])
-    else:
-        smaak = '{} with {}'.format(ingredients[0], " ".join(ingredients[1:]))
-    return smaak
+    logging.info("joining everything with spaces")
+    smaak = ' '.join(ingredients)
+    logging.info("removing space before comma")
+    return smaak.replace(" ,", ",")
 
 def generate_tony_flavours():
     ldg = cfg_generator.Grammar() # limited_edition_grammar

--- a/src/tony_cfg.py
+++ b/src/tony_cfg.py
@@ -1,8 +1,9 @@
 tony_nl = """
 S -> LIMITED_EDITION
-LIMITED_EDITION -> CHOCOLADESOORT SMAKEN
-SMAKEN -> SMAAK | SMAAK SMAAK | SMAAK SMAAK SMAAK
-SMAAK -> FRUIT | FRUITS CRUMBLE | NOTEN | DRANK | SNOEPGOED | KRUIDEN | GROENTEN | OVERIG | RAAR
+LIMITED_EDITION -> CHOCOLADESOORT MET SMAKEN
+SMAKEN -> LAATSTESMAAK | SMAAK EN LAATSTESMAAK | SMAAK KOMMA SMAAK EN LAATSTESMAAK
+LAATSTESMAAK -> SMAAK | SMAAK | SMAAK | SMAAK | FRUITS CRUMBLE
+SMAAK -> FRUIT | NOTEN | DRANK | SNOEPGOED | KRUIDEN | GROENTEN | OVERIG | RAAR
 CRUMBLE -> crumble
 FRUIT -> sinaasappel | ananas | framboos | peer | banaan | kokos | kers | cranberry | mango | kiwi | citroen | limoen | yuzu | zwarte bes | abrikoos | rozijn | vijg | gember | bosbes | meloen
 FRUITS -> peren | bananen | kersen | cranberry | rabarber | appel
@@ -14,14 +15,18 @@ KRUIDEN -> zeezout | zwarte peper | chili | rozemarijn | anijs | bergamot | kane
 OVERIG ->   honing | coffeecrunch | stoofpeer | butterscotch | gepofte rijst | viooltjes | wasabi | rode curry | groene curry | jalapenopeper | balsamico | lavendel | rozenblaadjes 
 RAAR -> mayonaise | ketchup | soyasaus | bouillon | slagroom | zoute drop | zalmsnippers
 CHOCOLADESOORT -> melkchocolade | donkere melkchocolade | blonde chocolade | extra pure chocolade | pure chocolade | witte chocolade
+MET -> met
+EN -> en
+KOMMA -> ,
 """
 
 tony_en = """
 S -> LIMITED_EDITION
-LIMITED_EDITION -> CHOCOLATETYPE INGREDIENTS
+LIMITED_EDITION -> CHOCOLATETYPE WITH INGREDIENTS
 CHOCOLATETYPE -> milk chocolate | dark milk chocolate | blonde chocolate | extra dark chocolate | dark chocolate | white chocolate
-INGREDIENTS -> INGREDIENT | INGREDIENT INGREDIENT | INGREDIENT INGREDIENT INGREDIENT
-INGREDIENT -> FRUIT | FRUIT CRUMBLE | NUTS | DRINK | SWEET | SPICE | VEGETABLE | MISC | WEIRD
+INGREDIENTS -> LASTINGREDIENT | INGREDIENT AND LASTINGREDIENT | INGREDIENT COMMA INGREDIENT AND LASTINGREDIENT
+LASTINGREDIENT -> INGREDIENT | INGREDIENT | INGREDIENT | INGREDIENT | FRUIT CRUMBLE
+INGREDIENT -> FRUIT | NUTS | DRINK | SWEET | SPICE | VEGETABLE | MISC | WEIRD
 CRUMBLE -> crumble
 FRUIT -> orange | pineapple | raspberry | pear | banana | coconut | cherry | cranberry | mango | kiwi | lemon | lime | yuzu | black currant | apricot | raisin | figs | ginger | blueberry | melon | rhubarb
 NUTS -> hazelnuts | macadamias | walnuts | pecans | almonds | peanuts | cashews | pumpkin seeds | sunflower seeds | sesame seeds | pistachios
@@ -31,4 +36,7 @@ VEGETABLE -> cucumber | grated carrot | beet | nori | parsnip | pumpkin | soy be
 SPICE -> sea salt | black pepper | chili | rosemary | aniseed | bergamot | cinnamon | jasmine | madame jeanette | bell pepper | white pepper | pink pepper | laurel | fennel seeds | cardamom | clove | nutmeg
 MISC -> honey | coffeecrunch | butterscotch | wasabi | red curry | green curry | jalapeno peppers | balsamic vinegar | lavender | rose petals | cornflakes
 WEIRD -> mayonnaise | ketchup | soy sauce | broth | whipped cream | liquorice | salmon
+WITH -> with
+AND -> and
+COMMA -> ,
 """


### PR DESCRIPTION
Doing (almost) everything in grammar eliminates the need fot the logic in `format_output()` removing the line `list(dict.fromkeys(...))` which did not work as intended pre-3.6 versions of Python.

Note about changes on getting crumble:
`LASTINGREDIENT -> INGREDIENT | INGREDIENT | INGREDIENT | INGREDIENT | FRUIT CRUMBLE` could also have been just `LASTINGREDIENT -> INGREDIENT | FRUIT CRUMBLE` but that would have had a more drastic impact on the output.
The change of at least one crumble was 2/9 (about 22%); I choose to go with a total change of 1/5 (20%) of having crumble, without duplication it would have been 1/2 (50%).